### PR TITLE
Change from a jQuery .on() to a mw.hook() trigger

### DIFF
--- a/modules/ext.codeEditor.js
+++ b/modules/ext.codeEditor.js
@@ -31,7 +31,10 @@ $( function () {
 	// Add code editor module
 	$wpTextbox1.wikiEditor( 'addModule', 'codeEditor' );
 
-	$wpTextbox1.on( 'wikiEditor-toolbar-doneInitialSections', function () {
+	// Previous trigger (prone to race conditions):
+	// $wpTextbox1.on( 'wikiEditor-toolbar-doneInitialSections', function () {
+	// New 'n' improved trigger:
+	mw.hook( 'wikiEditor.toolbarReady' ).add( function() {
 		$wpTextbox1.data( 'wikiEditor-context' ).fn.codeEditorMonitorFragment();
 	} );
 } );


### PR DESCRIPTION
From https://github.com/wikimedia/mediawiki-extensions-WikiEditor/blob/REL1_38/modules/jquery.wikiEditor.toolbar.js#L800
> // Use hook for attaching new toolbar tools to avoid race conditions

Excellent idea, as we're currently experiencing (and losing) a race condition.